### PR TITLE
Reset IDE Ready after Facade.TCPConnect

### DIFF
--- a/facade.go
+++ b/facade.go
@@ -36,11 +36,13 @@ func newFacade() *Facade {
 
 	return res
 }
-
 func (f *Facade) TcpConnect(L *lua.LState, host string, port int) error {
 	f.states[L] = struct{}{}
 	f.t = &Transport{}
 	f.t.Handler = f.HandleMsg
+	defer func() {
+		f.isIDEReady = false
+	}()
 	if err := f.t.Connect(host, port); err != nil {
 		LuaError(L, err.Error())
 		return err


### PR DESCRIPTION
Hey @edolphin-ydf ,

First off, great work on this gopherlua-debugger, and appreciate your work on this! So to give you a bit more context on what I'm doing - I'm trying to create a web editor utilizing Monaco Editor that enables Lua scripting  and gopherlua VM that binds to our proprietary code of controlling our robots. Moreover, I would like to expose troubleshooting to end users, and that's where your debugging library comes into play : )

Specifically though, there is a problem with the `reusability` of this code across multiple runs. You created a `singleton` of `Fcd`, and hence after the first successful Fcd.TcpConnect(), the state of facade.IDEReady == true for the remainder of however long the go-process runs.

This breaks my user flow because basically, everytime the user clicks "debug", I effectively will grab a new TCP port connection and ask that my web IDE prime the appropriate breakpoints and send ready. BUT after the first successful OnReady, it will basically bypass IDEReadyInit and not allow anytime for the IDE to re-send new breakpoints after tearing down the old run. My go-process is also long-lived because it's a server that spins up a lua run on demand / or by schedule.

Also if you were to refer to VSCode-EmmyLua - they also send OnReady per OnConnect so hopefully this is aligned with the understanding of the EmmyLua protocol. https://github.com/EmmyLua/VSCode-EmmyLua/blob/master/src/debugger/EmmyDebugSession.ts#L93-L114

What do you think? If this is against your design and intent, I can also hide it behind a global config flag (default false) so it doesn't affect other consumers of this library if they had a different understanding.