### PR TITLE
Allow Lua Script Cancelation to Break out of WaitForIDE Loop

### DIFF
--- a/facade.go
+++ b/facade.go
@@ -2,7 +2,6 @@ package lua_debugger
 
 import (
 	"context"
-	"fmt"
 	"github.com/edolphin-ydf/gopherlua-debugger/proto"
 	lua "github.com/yuin/gopher-lua"
 	"sync"


### PR DESCRIPTION
Hi @edolphin-ydf , 

Hope you don't mind this second PR : )

So for my Web editor -> gopher-lua server usecase, I essentially use a `websocket-tcp` bridge in order to send the appropriate messages to communicate with gopherlua-debugger.

However, I'm also trying to make the implementation robust upon failures - specifically when the websocket connection is dropped on the browser. Otherwise, every attempted debug run would create a new luaState.Run that's stuck on `facade.TCPConnect()` because it never receives the OnReadyCmd.

Hopefully this change looks ok to you. If not, that's ok as I have an alternative solution in which I emulate said OnReadyCmd when I sense websocket failure. However, it's a lot cleaner for me and more aligned with go paradigms to use context.